### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported benchmarks:
 Requires python3.9 (or latest) and python-poetry
 The repository uses many submodules.
 ```bash
-git clone --recurse-submodules ssh://github.com/ASSERT-KTH/elle-elle-aime.git
+git clone --recurse-submodules https://github.com/ASSERT-KTH/elle-elle-aime.git
 cd elle-elle-aime
 poetry install # installs dependencies
 


### PR DESCRIPTION
Change example repo clone string from `ssh://` to `https://` due to issues with mixed auth methods for main repo and submodule repos.

I could not clone because the main repo auth method was SSH in the example, while the .submodules auth method was HTTPS. If this is not repeatable the PR + branch can be removed. If SSH auth is preferred, the .gitmodules auth method can be changed to SSH. That should also be a valid fix (probably). 